### PR TITLE
Prefer HTTPS for sending security tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ CLI tool for sending data to Backdrop
 
 ## Install
 
-`pip install http://github.com/alphagov/backdropsend/tarball/0.0.1`
+`pip install https://github.com/alphagov/backdropsend/tarball/0.0.1`
 
 ## Example
 
-`backdrop-send --url http://location/of/backdrop/bucket --token TOPSECRET123456 myfile.json`
+`backdrop-send --url https://location/of/backdrop/bucket --token TOPSECRET123456 myfile.json`
 
 or
 
-`cat myfile.json | backdrop-send --url http://location/of/backdrop/bucket --token TOPSECRET123456`
+`cat myfile.json | backdrop-send --url https://location/of/backdrop/bucket --token TOPSECRET123456`

--- a/docs/backdrop-send.1
+++ b/docs/backdrop-send.1
@@ -30,13 +30,13 @@ backdrop-send \- send data to backdrop
 .SH DESCRIPTION
 Sends data to a bucket in 
 .B backdrop 
-over http using a bearer token for authentication.
+over https using a bearer token for authentication.
 .SH OPTIONS
 .IP "-h --help"
 print help message and exit
 .IP --url
 the url of the backdrop bucket eg.
-.I http://location_of_backdrop/my_bucket
+.I https://location_of_backdrop/my_bucket
 .IP --token
 the authorization token for the bucket
 .IP "--timeout num"


### PR DESCRIPTION
We do not listen on port 80, we should encourage people to use TLS all
the time.
