### PR TITLE
Sensible console message in case of timeout

### DIFF
--- a/backdropsend/send.py
+++ b/backdropsend/send.py
@@ -22,7 +22,9 @@ def post(data, arguments):
             return HTTP_ERROR.with_details({ 'status': response.status_code, 'message': response.text })
         
         return OK
-    except (requests.ConnectionError, requests.exceptions.Timeout) as e:
+    except requests.exceptions.Timeout as e:
+        return TIMEOUT_ERROR
+    except requests.ConnectionError as e:
         return CONNECTION_ERROR
 
 def post_attempts(arguments):

--- a/backdropsend/status.py
+++ b/backdropsend/status.py
@@ -19,4 +19,5 @@ UNAUTHORIZED = Status(4, "Unable to send to backdrop. "
 HTTP_ERROR = Status(8, "Unable to send to backdrop. Server responded with {status}. "
               "Error: {message}.")
 CONNECTION_ERROR = Status(16, "Unable to send to backdrop. Connection error.")
+TIMEOUT_ERROR = Status(32, "Unable to send to backdrop. Request timeout.")
 

--- a/tests/functional/test_timeouts.py
+++ b/tests/functional/test_timeouts.py
@@ -22,7 +22,7 @@ class TestTimeout(unittest.TestCase):
         assert_that(cmd.exit_status, is_not(0))
         assert_that(cmd.stderr, contains_string(
             "Unable to send to backdrop. "
-            "Connection error."))
+            "Request timeout."))
 
     def test_it_fails_when_request_takes_longer_than_specified_timeout(self):
         HttpStub.set_response_delay(2)
@@ -35,7 +35,7 @@ class TestTimeout(unittest.TestCase):
         assert_that(cmd.exit_status, is_not(0))
         assert_that(cmd.stderr, contains_string(
             "Unable to send to backdrop. "
-            "Connection error."))       
+            "Request timeout."))
 
     def test_it_passes_when_request_takes_less_than_specified_timeout(self):
         HttpStub.set_response_delay(1)


### PR DESCRIPTION
If the request fails because of a timeout, show the message:
`Unable to send to backdrop. Request timeout.`
