### PR TITLE
Remove python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
- - "2.6"
  - "2.7"
 
 install: "pip install -q -r requirements_for_tests.txt --use-mirrors"


### PR DESCRIPTION
![](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQzmYvEZDfE6eN2C9JEHpCfFgtK6ge_y3bnNji9T9DlSkzgkGbMhMa9_bY)![](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQzmYvEZDfE6eN2C9JEHpCfFgtK6ge_y3bnNji9T9DlSkzgkGbMhMa9_bY)![](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQzmYvEZDfE6eN2C9JEHpCfFgtK6ge_y3bnNji9T9DlSkzgkGbMhMa9_bY)![](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQzmYvEZDfE6eN2C9JEHpCfFgtK6ge_y3bnNji9T9DlSkzgkGbMhMa9_bY)![](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQzmYvEZDfE6eN2C9JEHpCfFgtK6ge_y3bnNji9T9DlSkzgkGbMhMa9_bY)![](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQzmYvEZDfE6eN2C9JEHpCfFgtK6ge_y3bnNji9T9DlSkzgkGbMhMa9_bY)![](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQzmYvEZDfE6eN2C9JEHpCfFgtK6ge_y3bnNji9T9DlSkzgkGbMhMa9_bY)![](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQzmYvEZDfE6eN2C9JEHpCfFgtK6ge_y3bnNji9T9DlSkzgkGbMhMa9_bY)![](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQzmYvEZDfE6eN2C9JEHpCfFgtK6ge_y3bnNji9T9DlSkzgkGbMhMa9_bY)![](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQzmYvEZDfE6eN2C9JEHpCfFgtK6ge_y3bnNji9T9DlSkzgkGbMhMa9_bY)![](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQzmYvEZDfE6eN2C9JEHpCfFgtK6ge_y3bnNji9T9DlSkzgkGbMhMa9_bY)![](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQzmYvEZDfE6eN2C9JEHpCfFgtK6ge_y3bnNji9T9DlSkzgkGbMhMa9_bY)![](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQzmYvEZDfE6eN2C9JEHpCfFgtK6ge_y3bnNji9T9DlSkzgkGbMhMa9_bY)![](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQzmYvEZDfE6eN2C9JEHpCfFgtK6ge_y3bnNji9T9DlSkzgkGbMhMa9_bY)![](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQzmYvEZDfE6eN2C9JEHpCfFgtK6ge_y3bnNji9T9DlSkzgkGbMhMa9_bY)
- It was failing on travis
- We don't really care about 2.6 because it's not running anywhere
